### PR TITLE
add setAppVersion method

### DIFF
--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -301,4 +301,13 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
             tracker.setAppName(appName);
         }
     }
+    @ReactMethod
+    public void setAppVersion(String trackerId, String appVersion){
+        Tracker tracker = getTracker(trackerId);
+
+        if (tracker != null)
+        {
+            tracker.setAppVersion(appVersion);
+        }
+    }
 }

--- a/index.js
+++ b/index.js
@@ -168,6 +168,16 @@ class GoogleAnalytics {
     static setTrackerId(trackerId) {
         _trackerId = trackerId;
     }
+
+    /**
+     * Sets the trackers appVersion
+     * @param {String} appVersion
+     */
+    static setAppVersion(appVersion) {
+        GoogleAnalyticsBridge.setAppVersion(getTrackerId(), appVersion);
+    }
+
+
 }
 
 class GoogleTagManager {

--- a/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
+++ b/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
@@ -200,4 +200,10 @@ RCT_EXPORT_METHOD(setAppName:(NSString *)trackerId appName:(NSString *)appName)
     [tracker set:kGAIAppName value:appName];
 }
 
+RCT_EXPORT_METHOD(setAppVersion:(NSString *)trackerId appVersion:(NSString *)appVersion)
+{
+    id<GAITracker> tracker = [[GAI sharedInstance] trackerWithTrackingId:trackerId];
+    [tracker set:kGAIAppVersion value:appVersion];
+}
+
 @end


### PR DESCRIPTION
This adds setAppVersion method that comes handy when delivering version updated OTA (e.g. CodePush). https://github.com/idehub/react-native-google-analytics-bridge/issues/44