### PR TITLE
Track metrics and dimensions for event - Android only

### DIFF
--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -246,7 +246,7 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
     @ReactMethod
     public void trackEventWithCustomDimensionValues(String trackerId, String category, String action, ReadableMap optionalValues, ReadableMap dimensionIndexValues)
     {
-        self.trackEventWithCustomDimensionAndMetricValues(trackerId, category, action, optionalValues, dimensionIndexValues, null);
+        this.trackEventWithCustomDimensionAndMetricValues(trackerId, category, action, optionalValues, dimensionIndexValues, null);
     }
 
     @ReactMethod
@@ -280,7 +280,7 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
               ReadableMapKeySetIterator metricIterator = metricIndexValues.keySetIterator();
               while (metricIterator.hasNextKey()) {
                   String metricIndex = metricIterator.nextKey();
-                  String metricValue = metricIndexValues.getInt(metricIndex);
+                  int metricValue = metricIndexValues.getInt(metricIndex);
                   hit.setCustomMetric(Integer.parseInt(metricIndex), metricValue);
               }
             }

--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -246,6 +246,12 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
     @ReactMethod
     public void trackEventWithCustomDimensionValues(String trackerId, String category, String action, ReadableMap optionalValues, ReadableMap dimensionIndexValues)
     {
+        self.trackEventWithCustomDimensionAndMetricValues(trackerId, category, action, optionalValues, dimensionIndexValues, null)
+    }
+
+    @ReactMethod
+    public void trackEventWithCustomDimensionAndMetricValues(String trackerId, String category, String action, ReadableMap optionalValues, ReadableMap dimensionIndexValues, ReadableMap metricIndexValues)
+    {
         Tracker tracker = getTracker(trackerId);
 
         if (tracker != null)
@@ -253,7 +259,7 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
             HitBuilders.EventBuilder hit = new HitBuilders.EventBuilder()
                         .setCategory(category)
                         .setAction(action);
-                        
+
             if (optionalValues.hasKey("label"))
             {
                 hit.setLabel(optionalValues.getString("label"));
@@ -268,6 +274,15 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
                 String dimensionIndex = iterator.nextKey();
                 String dimensionValue = dimensionIndexValues.getString(dimensionIndex);
                 hit.setCustomDimension(Integer.parseInt(dimensionIndex), dimensionValue);
+            }
+
+            if(metricIndexValues != null){
+              ReadableMapKeySetIterator metricIterator = metricIndexValues.keySetIterator();
+              while (metricIterator.hasNextKey()) {
+                  String metricIndex = metricIterator.nextKey();
+                  String metricValue = metricIndexValues.getInt(metricIndex);
+                  hit.setCustomMetric(Integer.parseInt(metricIndex), metricValue);
+              }
             }
 
             tracker.send(hit.build());

--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -246,7 +246,7 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
     @ReactMethod
     public void trackEventWithCustomDimensionValues(String trackerId, String category, String action, ReadableMap optionalValues, ReadableMap dimensionIndexValues)
     {
-        self.trackEventWithCustomDimensionAndMetricValues(trackerId, category, action, optionalValues, dimensionIndexValues, null)
+        self.trackEventWithCustomDimensionAndMetricValues(trackerId, category, action, optionalValues, dimensionIndexValues, null);
     }
 
     @ReactMethod

--- a/index.js
+++ b/index.js
@@ -52,6 +52,18 @@ class GoogleAnalytics {
     }
 
     /**
+     * Track an event that has both custom dimension and metric values.
+     * @param  {String} category       The event category
+     * @param  {String} action         The event action
+     * @param  {Object} optionalValues An object containing optional label and value
+     * @param  {Object} customDimensionValues An object containing custom dimension key/value pairs
+     * @param  {Object} customMetricValues An object containing custom metric key/value pairs
+     */
+    static trackEventWithCustomDimensionAndMetricValues(category, action, optionalValues = {}, customDimensionValues, customMetricValues) {
+        GoogleAnalyticsBridge.trackEventWithCustomDimensionAndMetricValues(getTrackerId(), category, action, optionalValues, customDimensionValues, customMetricValues);
+    }
+
+    /**
      * Track an event that has occured
      * @param  {String} category       The event category
      * @param  {Number} value         	The timing measurement in milliseconds


### PR DESCRIPTION
There was no way to track a metric, so I just created another bridged API call (Android) so that I can pass in the metrics. Verified that the metrics were being recorded on Google Analytics.
