### PR TITLE
 - fix for trackMultiProductsPurchaseEventWithCustomDimensionValues method

### DIFF
--- a/src/GoogleAnalyticsTracker.js
+++ b/src/GoogleAnalyticsTracker.js
@@ -130,7 +130,7 @@ export class GoogleAnalyticsTracker {
    */
   trackMultiProductsPurchaseEventWithCustomDimensionValues(products = [], transaction = {}, eventCategory = "Ecommerce", eventAction = "Purchase", customDimensions) {
     const formattedCustomDimensions = this.transformCustomDimensionsFieldsToIndexes(customDimensions);
-    GoogleAnalyticsBridge.trackMultiProductsPurchaseEvent(this.id, products, transaction, eventCategory, eventAction, formattedCustomDimensions);
+    GoogleAnalyticsBridge.trackMultiProductsPurchaseEventWithCustomDimensionValues(this.id, products, transaction, eventCategory, eventAction, formattedCustomDimensions);
   }
 
   /**


### PR DESCRIPTION
Hi, 
trackMultiProductsPurchaseEventWithCustomDimensionValues of GoogleAnalyticsTracker calls GoogleAnalyticsBridge.trackMultiProductsPurchaseEvent in master instead of GoogleAnalyticsBridge.trackMultiProductsPurchaseEventWithCustomDimensionValues.
The PR fixes this issue.