### PR TITLE
Missing AdSupport in podspec

### DIFF
--- a/react-native-google-analytics-bridge.podspec
+++ b/react-native-google-analytics-bridge.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
 
-  s.frameworks = 'CoreData', 'SystemConfiguration'
+  s.frameworks = 'CoreData', 'SystemConfiguration', 'AdSupport'
   s.libraries = 'z', 'sqlite3.0','GoogleAnalyticsServices','AdIdAccess'
 
   s.vendored_libraries =


### PR DESCRIPTION
Since this includes the libAdIdAcess we must include AdSupport.framework