### PR TITLE
The pushDataLayerEvent method in GoogleTagManager.js wasn't returning…

### DIFF
--- a/src/GoogleTagManager.js
+++ b/src/GoogleTagManager.js
@@ -41,6 +41,6 @@ export class GoogleTagManager {
    *         example: {event: "eventName", pageId: "/home"}
    */
   static pushDataLayerEvent(dictionary = {}){
-    GoogleTagManagerBridge.pushDataLayerEvent(dictionary);
+    return GoogleTagManagerBridge.pushDataLayerEvent(dictionary);
   }
 }


### PR DESCRIPTION
… a promise. Updated the static method to return the promise that is created from the GoogleTagManagerBridge method.