### PR TITLE
Load local GTM file if exists (lowercase and all hyphens to underscore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build/
 .gradle
 local.properties
 *.iml
+android/gradle*
 
 # Node
 node_modules

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ GoogleTagManager.openContainerWithId("GT-NZT48")
   * [GoogleAnalyticsSettings](#googleanalyticssettings-api)
   * [GoogleTagManager](#googletagmanager-api)
 
+-------------------------------------------------------------------------------
+
 ## GoogleAnalyticsTracker API
 
 ### new GoogleAnalyticsTracker(trackerId, customDimensionsFieldsIndexMap = {})
@@ -360,6 +362,8 @@ Sets tracker sampling rate.
 tracker.setSamplingRate(50);
 ```
 
+-------------------------------------------------------------------------------
+
 ## GoogleAnalyticsSettings API
 
 Settings are applied across all trackers.
@@ -396,13 +400,31 @@ Note: This has to be set each time the App starts.
 GoogleAnalyticsSettings.setOptOut(true);
 ```
 
+-------------------------------------------------------------------------------
+
 ## GoogleTagManager API
+
+> #### Bundling the Google Tag Manager Binary file with your app
+> 
+> #### Android
+>
+*Note:* You must rename the file to lowercase and replace hyphens `-` with underscores `_` (e.g: `GT-NZT48` → `gt_nzt48`).  
+> - Copy your pre-loaded GTM binary into → `YourReactApp/android/app/src/main/res/raw/gt_nzt48`.  
+>
+> #### iOS
+>
+> *Note: Do not rename the file on iOS*
+>
+> Copy your pre-loaded GTM binary into your project (copy items if needed).
+> - Project → Build Phases → Copy Bundle Resources → "Add GTM file here" 
+>
 
 ```javascript
 import { GoogleTagManager } from 'react-native-google-analytics-bridge';
 GoogleTagManager.openContainerWithId('GT-NZT48')
 .then(() => GoogleTagManager.stringForKey('pack'))
-.then((str) => console.log('Pack: ', str));
+.then((str) => console.log('Pack: ', str))
+.catch((err) => console.error('GTM failed to load, check your network or bundled file.', err));
 ```
 
 Can only be used with one container. All methods returns a `Promise`.
@@ -414,7 +436,7 @@ Can only be used with one container. All methods returns a `Promise`.
 
 ```javascript
 GoogleTagManager.openContainerWithId('GT-NZT48')
-.then((..) => ..)
+.then(() => {})
 ```
 
 ### stringForKey(key)

--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleTagManagerBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleTagManagerBridge.java
@@ -51,9 +51,12 @@ public class GoogleTagManagerBridge extends ReactContextBaseJavaModule {
         }
 
         TagManager mTagManager = TagManager.getInstance(getReactApplicationContext());
-        //using -1 here because it can't access raw in app
+        // Try loading raw file from our app bundle ('GT-NZT48' -> res/raw/gt_nzt48), else -1 to load latest from the GTM network
+        ReactApplicationContext reactContext = getReactApplicationContext();
+        final String guessedLocalFileName = containerId.replaceAll("([-])", "_").toLowerCase();
+        int localGtmFile = reactContext.getResources().getIdentifier(guessedLocalFileName, "raw", getReactApplicationContext().getPackageName());
         openOperationInProgress = true;
-        PendingResult<ContainerHolder> pending = mTagManager.loadContainerPreferFresh(containerId, -1);
+        PendingResult<ContainerHolder> pending = mTagManager.loadContainerPreferFresh(containerId, localGtmFile != 0 ? localGtmFile : -1);
         pending.setResultCallback(new ResultCallback<ContainerHolder>() {
             @Override
             public void onResult(ContainerHolder containerHolder) {


### PR DESCRIPTION
 - .gitignore - Ignore local android gradle files (android studio)
 - Updated Readme with instructions
 - Patch GoogleTagManagerBridge.java to try and load a local GTM file

---

Adds the above, when loading an app for the first time on a offline connection, we are thrown "unable to open container" - This allows us to package a file with android like on iOS so GTM can fallback to the default preloaded container if no network connection.

Thanks!