### PR TITLE
Track campaign from url

### DIFF
--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -416,4 +416,17 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
             tracker.setAppVersion(appVersion);
         }
     }
+
+    @ReactMethod
+    public void getCampaignFromUrl(String trackerId, String urlString){
+        Tracker tracker = getTracker(trackerId);
+
+        if (tracker != null)
+        {
+            tracker.setScreenName("Init With Campaign")
+            tracker.send(new HitBuilders.ScreenViewBuilder()
+            .setCampaignParamsFromUrl(urlString)
+            .build()
+        }
+    }
 }

--- a/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
+++ b/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
@@ -310,4 +310,37 @@ RCT_EXPORT_METHOD(setAppVersion:(NSString *)trackerId appVersion:(NSString *)app
     [tracker set:kGAIAppVersion value:appVersion];
 }
 
+
+RCT_EXPORT_METHOD(trackCampaignFromUrl:(NSString *)trackerId urlString:(NSString *)urlString)
+{
+    id<GAITracker> tracker = [[GAI sharedInstance] trackerWithTrackingId:trackerId];
+    
+    // setCampaignParametersFromUrl: parses Google Analytics campaign ("UTM")
+    // parameters from a string url into a Map that can be set on a Tracker.
+    GAIDictionaryBuilder *hitParams = [[GAIDictionaryBuilder alloc] init];
+    
+    // Set campaign data on the map, not the tracker directly because it only
+    // needs to be sent once.
+    [hitParams setCampaignParametersFromUrl:urlString];
+    
+    // Campaign source is the only required campaign field. If previous call
+    // did not set a campaign source, use the hostname as a referrer instead.
+    if(![hitParams get:kGAICampaignSource] && [url host].length !=0) {
+        // Set campaign data on the map, not the tracker.
+        [hitParams set:@"referrer" forKey:kGAICampaignMedium];
+        [hitParams set:[url host] forKey:kGAICampaignSource];
+    }
+    
+    NSDictionary *hitParamsDict = [hitParams build];
+    
+    // A screen name is required for a screen view.
+    [tracker set:kGAIScreenName value:@"Init With Campaign"];
+    
+    // Previous V3 SDK versions.
+    // [tracker send:[[[GAIDictionaryBuilder createAppView] setAll:hitParamsDict] build]];
+    
+    // SDK Version 3.08 and up.
+    [tracker send:[[[GAIDictionaryBuilder createScreenView] setAll:hitParamsDict] build]];
+}
+
 @end

--- a/src/GoogleAnalyticsTracker.js
+++ b/src/GoogleAnalyticsTracker.js
@@ -58,7 +58,7 @@ export class GoogleAnalyticsTracker {
   
   /**
    * Track the campaign from url
-   * @param  {String} screenUrl The url of the deep link
+   * @param  {String} urlString The url of the deep link
    */
   trackCampaignFromUrl(urlString) {
     GoogleAnalyticsBridge.trackCampaignFromUrl(this.id, urlString);

--- a/src/GoogleAnalyticsTracker.js
+++ b/src/GoogleAnalyticsTracker.js
@@ -55,6 +55,14 @@ export class GoogleAnalyticsTracker {
   trackScreenView(screenName) {
     GoogleAnalyticsBridge.trackScreenView(this.id, screenName);
   }
+  
+  /**
+   * Track the campaign from url
+   * @param  {String} screenUrl The url of the deep link
+   */
+  trackCampaignFromUrl(urlString) {
+    GoogleAnalyticsBridge.trackCampaignFromUrl(this.id, urlString);
+  }
 
   /**
    * Track an event that has occured


### PR DESCRIPTION
This add a new function to initialize campaign tracking from a given url, this can be  a deep link or any url.

Extracted from analytics docs:
https://developers.google.com/analytics/devguides/collection/android/v4/campaigns
https://developers.google.com/analytics/devguides/collection/ios/v3/campaigns