### PR TITLE
Fixes crashes caused by null parameters

### DIFF
--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -76,13 +76,16 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
                         .setCategory(category)
                         .setAction(action);
 
-            if (optionalValues.hasKey("label"))
+            if (optionalValues != null)
             {
-                hit.setLabel(optionalValues.getString("label"));
-            }
-            if (optionalValues.hasKey("value"))
-            {
-                hit.setValue(optionalValues.getInt("value"));
+                if (optionalValues.hasKey("label"))
+                {
+                    hit.setLabel(optionalValues.getString("label"));
+                }
+                if (optionalValues.hasKey("value"))
+                {
+                    hit.setValue(optionalValues.getInt("value"));
+                }
             }
 
             tracker.send(hit.build());
@@ -99,13 +102,16 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
                         .setCategory(category)
                         .setValue(value.longValue());
 
-            if (optionalValues.hasKey("name"))
+            if (optionalValues != null)
             {
-                hit.setVariable(optionalValues.getString("name"));
-            }
-            if (optionalValues.hasKey("label"))
-            {
-                hit.setLabel(optionalValues.getString("label"));
+                if (optionalValues.hasKey("name"))
+                {
+                    hit.setVariable(optionalValues.getString("name"));
+                }
+                if (optionalValues.hasKey("label"))
+                {
+                    hit.setLabel(optionalValues.getString("label"));
+                }
             }
 
             tracker.send(hit.build());
@@ -317,13 +323,17 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
                         .setCategory(category)
                         .setAction(action);
 
-            if (optionalValues.hasKey("label"))
+
+            if (optionalValues != null)
             {
-                hit.setLabel(optionalValues.getString("label"));
-            }
-            if (optionalValues.hasKey("value"))
-            {
-                hit.setValue(optionalValues.getInt("value"));
+                if (optionalValues.hasKey("label"))
+                {
+                    hit.setLabel(optionalValues.getString("label"));
+                }
+                if (optionalValues.hasKey("value"))
+                {
+                    hit.setValue(optionalValues.getInt("value"));
+                }
             }
 
             ReadableMapKeySetIterator iterator = dimensionIndexValues.keySetIterator();


### PR DESCRIPTION
If the React Native side does not pass a value for the parameter `optionalValues`, it resolves as `null` in the parameter for the native Android method. This can cause NullPointerExceptions when we attempt to call the method `.hasKey()` on a null object. 

These checks will avoid crashes if the JS method does not supply an empty object to the parameter of `optionalValues`.