### PR TITLE
Removed deprecated method (createJSModules) of React Native 0.47.0

### DIFF
--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridgePackage.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridgePackage.java
@@ -33,7 +33,7 @@ public class GoogleAnalyticsBridgePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Hi,
I know you merged https://github.com/idehub/react-native-google-analytics-bridge/pull/145 before, but seems reverted it for some reason. 
And React Native release 0.47.0 today. So I think we can do this commit here. :)

Thank you.
