### PR TITLE
Method to set clientId - Android & iOS

### DIFF
--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -270,6 +270,16 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setClient(String trackerId, String clientId)
+    {
+        Tracker tracker = getTracker(trackerId);
+
+        if (tracker != null) {
+            tracker.set("&cid", clientId);
+        }
+    }
+
+    @ReactMethod
     public void allowIDFA(String trackerId, Boolean enabled)
     {
         Tracker tracker = getTracker(trackerId);

--- a/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
+++ b/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
@@ -251,6 +251,13 @@ RCT_EXPORT_METHOD(setUser:(NSString *)trackerId userId:(NSString *)userId)
          value:userId];
 }
 
+RCT_EXPORT_METHOD(setClient:(NSString *)trackerId clientId:(NSString *)clientId)
+{
+    id<GAITracker> tracker = [[GAI sharedInstance] trackerWithTrackingId:trackerId];
+    [tracker set:kGAIClientId
+           value:clientId];
+}
+
 RCT_EXPORT_METHOD(allowIDFA:(NSString *)trackerId enabled:(BOOL)enabled)
 {
     id<GAITracker> tracker = [[GAI sharedInstance] trackerWithTrackingId:trackerId];

--- a/src/GoogleAnalyticsTracker.js
+++ b/src/GoogleAnalyticsTracker.js
@@ -159,6 +159,14 @@ export class GoogleAnalyticsTracker {
   }
 
   /**
+   * Sets the current clientId for tracking.
+   * @param {String} clientId The current userId
+   */
+  setClient(clientId) {
+    GoogleAnalyticsBridge.setClient(this.id, clientId);
+  }
+
+  /**
    * Sets if IDFA (identifier for advertisers) collection should be enabled
    * @param  {Boolean} enabled Defaults to true
    */


### PR DESCRIPTION
Added method to allow to set the client Id for each tracker (https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#clientId)