### PR TITLE
Support react-native +0.48 warning

### DIFF
--- a/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
+++ b/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
@@ -377,4 +377,9 @@ RCT_EXPORT_METHOD(createNewSession:(NSString *)trackerId screenName:(NSString *)
     [tracker send:[builder build]];
 }
 
+(BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
Will be deprecated in futures releases per stated by the warning:

`In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.`

Fixes #186 