### PR TITLE
Add dispatchWithCompletionHandler

### DIFF
--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.Promise;
 
 import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.HitBuilders;
@@ -480,5 +481,12 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
         Tracker tracker = getTracker(trackerId);
         tracker.setScreenName(screenName);
         tracker.send(new HitBuilders.ScreenViewBuilder().setNewSession().build());
+    }
+
+    @ReactMethod
+    public void dispatch(Promise promise) {
+        GoogleAnalytics analytics = GoogleAnalytics.getInstance(getReactApplicationContext());
+        analytics.dispatchLocalHits();
+        promise.resolve(true);
     }
 }

--- a/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
+++ b/android/src/main/java/com/idehub/GoogleAnalyticsBridge/GoogleAnalyticsBridge.java
@@ -485,8 +485,12 @@ public class GoogleAnalyticsBridge extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void dispatch(Promise promise) {
-        GoogleAnalytics analytics = GoogleAnalytics.getInstance(getReactApplicationContext());
-        analytics.dispatchLocalHits();
-        promise.resolve(true);
+        GoogleAnalytics analytics = getAnalyticsInstance();
+        try {
+            analytics.dispatchLocalHits();
+            promise.resolve(true);
+        } catch (Exception ex) {
+            promise.reject(ex);
+        }
     }
 }

--- a/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
+++ b/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
@@ -378,9 +378,13 @@ RCT_EXPORT_METHOD(createNewSession:(NSString *)trackerId screenName:(NSString *)
 }
 
 RCT_EXPORT_METHOD(dispatch:(RCTPromiseResolveBlock)resolve
-                  reject:(__unused RCTPromiseRejectBlock)reject) {
+                  reject:(RCTPromiseRejectBlock)reject) {
     [[GAI sharedInstance] dispatchWithCompletionHandler:^void(GAIDispatchResult result){
-        resolve(result != kGAIDispatchError ? @YES : @NO);
+        if (result != kGAIDispatchError) {
+            resolve(@YES);
+        } else {
+            reject(@"DISPATCH_FAILED", nil, RCTErrorWithMessage(@"Dispatch failed"));
+        }
     }];
 }
 

--- a/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
+++ b/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
@@ -377,6 +377,13 @@ RCT_EXPORT_METHOD(createNewSession:(NSString *)trackerId screenName:(NSString *)
     [tracker send:[builder build]];
 }
 
+RCT_EXPORT_METHOD(dispatch:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject) {
+    [[GAI sharedInstance] dispatchWithCompletionHandler:^void(GAIDispatchResult result){
+        resolve(result != kGAIDispatchError ? @YES : @NO);
+    }];
+}
+
 + (BOOL)requiresMainQueueSetup
 {
     return YES;

--- a/src/GoogleAnalyticsTracker.js
+++ b/src/GoogleAnalyticsTracker.js
@@ -1,5 +1,7 @@
 import { GoogleAnalyticsBridge } from './NativeBridges';
 
+const DEFAULT_DISPATCH_TIMEOUT = 15000;
+
 /**
  * Custom dimensions accept only strings and numbers.
  * @param customDimensionVal
@@ -250,25 +252,25 @@ export class GoogleAnalyticsTracker {
   }
 
   dispatch() {
-    return GoogleAnalyticsBridge.dispatch()
+    return GoogleAnalyticsBridge.dispatch();
   }
 
   dispatchWithTimeout(timeout = -1) {
     if (timeout < 0) {
-      return this.dispatch()
+      return GoogleAnalyticsBridge.dispatch();
     }
 
     const withTimeout = timeout => (
       new Promise(resolve => {
         setTimeout(() => {
-          resolve()
-        }, (timeout > 15000) ? 15000 : timeout)
+          resolve();
+        }, Math.min(timeout, DEFAULT_DISPATCH_TIMEOUT));
       })
-    )
+    );
 
     return Promise.race([
       GoogleAnalyticsBridge.dispatch(),
       withTimeout(timeout)
-    ])
+    ]);
   }
 }

--- a/src/GoogleAnalyticsTracker.js
+++ b/src/GoogleAnalyticsTracker.js
@@ -248,4 +248,27 @@ export class GoogleAnalyticsTracker {
   createNewSession(screenName) {
     GoogleAnalyticsBridge.createNewSession(this.id, screenName);
   }
+
+  dispatch() {
+    return GoogleAnalyticsBridge.dispatch()
+  }
+
+  dispatchWithTimeout(timeout = -1) {
+    if (timeout < 0) {
+      return this.dispatch()
+    }
+
+    const withTimeout = timeout => (
+      new Promise(resolve => {
+        setTimeout(() => {
+          resolve()
+        }, (timeout > 15000) ? 15000 : timeout)
+      })
+    )
+
+    return Promise.race([
+      GoogleAnalyticsBridge.dispatch(),
+      withTimeout(timeout)
+    ])
+  }
 }

--- a/src/GoogleAnalyticsTracker.js
+++ b/src/GoogleAnalyticsTracker.js
@@ -260,9 +260,12 @@ export class GoogleAnalyticsTracker {
       return GoogleAnalyticsBridge.dispatch();
     }
 
+    let timer = null;
+
     const withTimeout = timeout => (
       new Promise(resolve => {
-        setTimeout(() => {
+        timer = setTimeout(() => {
+          timer = null;
           resolve();
         }, Math.min(timeout, DEFAULT_DISPATCH_TIMEOUT));
       })
@@ -271,6 +274,11 @@ export class GoogleAnalyticsTracker {
     return Promise.race([
       GoogleAnalyticsBridge.dispatch(),
       withTimeout(timeout)
-    ]);
+    ]).then(result => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      return result;
+    });
   }
 }


### PR DESCRIPTION
Add dispatchWithCompletionHandler to ensure sending data when app becomes background. (Fix #211)

Usage:

```js
import { Linking, NativeModules } from 'react-native';
const { GoogleAnalyticsBridge } = NativeModules;

// ... open lind
tracker.trackEvent('category', 'event name');

GoogleAnalyticsBridge.dispatchWithCompletionHandler()
.then(() => {
  Linking.openURL('https://example.com')
})
```