### PR TITLE
214 typings fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -275,7 +275,7 @@ declare module "react-native-google-analytics-bridge" {
          * @param {Number} timeout The timeout. Default value is 15 sec.
          * @returns {Promise<boolean>} Returns when done or timed out
          */
-        dispatchWithTimeout(timeout: number = -1): Promise<boolean>
+        dispatchWithTimeout(timeout: number): Promise<boolean>
     }
 
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -275,7 +275,7 @@ declare module "react-native-google-analytics-bridge" {
          * @param {Number} timeout The timeout. Default value is 15 sec.
          * @returns {Promise<boolean>} Returns when done or timed out
          */
-        dispatchWithTimeout(timeout: number): Promise<boolean>
+        dispatchWithTimeout(timeout?: number): Promise<boolean>
     }
 
     /**


### PR DESCRIPTION
Me again, just looking further into the source code, it appears I was too hasty with my previous PR. I believe the _intent_ of the `= -1` is because the timeout parameter is optional. This PR makes the `timeout` parameter optional in the type definitions.

#214 