### PR TITLE
Validate type definition as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
-language: nodejs
-install:
-- npm config set spin=false
-- npm config set progress=false
-- npm install
-script: npm test
-notifications:
-  slack:
-    secure: qYpqErlZSfd5a88azsJqRkR0dKGXJknLoNsB/MuutbMbsX2HZzRfee9pDR1CDfcLlyBInRoN2lzv2B6xfrRDFnXWB/K9sRjTmzwXVPZbI1KDIi0CpQpgioZeNu2vaqJroX++1RdBCqUE9cHPRUmgo5/SqS4Qnl13uGTyGX4rYHrRK6HC1mXZ7/rVvLg6UnXn6Mb46DSRnFEmGRNlHbw/TmaYDZpFtjxqI9UyTfgrTNaMpXkSrfXlQzYwAfJUaWNClXtk87SFx54UIeu2elCwoPYZozeGDQMi1evPnGUFXwQ+vfnJTFzwt4klr6cdZ1/spmzxzewGheG3pmUnYaKxf3QTD3ppOyE+A44/9eEMib7qUxo2cIv2KOyYLE/pAu3293GhvP4SEdBELLzVHDh4brc6nNndNetJ+GKHeXqIOx48fe3hwfZ+UDCV3KzjUbeiSfh45eEUqEGRRkRLgkB3vC8sKx101vQj2N990h50/CW0+F0nz0S7sDEVfbN9M3RuCtDmpUikTlYCEb1Y6k2uCNbgLuhV99VBVWOrUSB8aBhLPui+xYd+tSUD476mjqqowxYy5O0fbTouf2VzKgGmpyZ3DFvRgG1jbLKKBJxIQJcGq9fITTlh/BouoCAt2BK0JPG1rd+T91lovyqfMrnzrgiGrVIBHzpbh8i3V1H/vN0=
+language: node_js
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
+node_js: node
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
-language: node_js
+language: nodejs
 node_js: node
-
-
+install:
+- npm config set spin=false
+- npm config set progress=false
+- npm install
+script: npm test
+notifications:
+  slack:
+    secure: qYpqErlZSfd5a88azsJqRkR0dKGXJknLoNsB/MuutbMbsX2HZzRfee9pDR1CDfcLlyBInRoN2lzv2B6xfrRDFnXWB/K9sRjTmzwXVPZbI1KDIi0CpQpgioZeNu2vaqJroX++1RdBCqUE9cHPRUmgo5/SqS4Qnl13uGTyGX4rYHrRK6HC1mXZ7/rVvLg6UnXn6Mb46DSRnFEmGRNlHbw/TmaYDZpFtjxqI9UyTfgrTNaMpXkSrfXlQzYwAfJUaWNClXtk87SFx54UIeu2elCwoPYZozeGDQMi1evPnGUFXwQ+vfnJTFzwt4klr6cdZ1/spmzxzewGheG3pmUnYaKxf3QTD3ppOyE+A44/9eEMib7qUxo2cIv2KOyYLE/pAu3293GhvP4SEdBELLzVHDh4brc6nNndNetJ+GKHeXqIOx48fe3hwfZ+UDCV3KzjUbeiSfh45eEUqEGRRkRLgkB3vC8sKx101vQj2N990h50/CW0+F0nz0S7sDEVfbN9M3RuCtDmpUikTlYCEb1Y6k2uCNbgLuhV99VBVWOrUSB8aBhLPui+xYd+tSUD476mjqqowxYy5O0fbTouf2VzKgGmpyZ3DFvRgG1jbLKKBJxIQJcGq9fITTlh/BouoCAt2BK0JPG1rd+T91lovyqfMrnzrgiGrVIBHzpbh8i3V1H/vN0=

--- a/index.d.ts
+++ b/index.d.ts
@@ -276,6 +276,7 @@ declare module "react-native-google-analytics-bridge" {
          * @returns {Promise<boolean>} Returns when done or timed out
          */
         dispatchWithTimeout(timeout?: number): Promise<boolean>
+    }
 
     /**
      * Google analytics settings shared across all GoogleAnalyticsTracker instances.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test yet!\" && exit 0",
+    "test": "npm run dtslint",
     "dtslint": "dtslint ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test yet!\" && exit 0"
+    "test": "echo \"Error: no test yet!\" && exit 0",
+    "dtslint": "dtslint ."
   },
   "repository": {
     "type": "git",
@@ -41,5 +42,8 @@
         "libsqlite3.0.tbd"
       ]
     }
+  },
+  "devDependencies": {
+    "dtslint": "^0.2.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "noEmit": true,
+
+        // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
+        // If the library is global (cannot be imported via `import` or `require`), leave this out.
+        "baseUrl": ".",
+        "paths": { "mylib": ["."] }
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,6 @@
         "strictNullChecks": true,
         "strictFunctionTypes": false,
         "noEmit": true,
-
-        // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
-        // If the library is global (cannot be imported via `import` or `require`), leave this out.
         "baseUrl": ".",
         "paths": { "mylib": ["."] }
     }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,12 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "indent": false,
+        "no-redundant-jsdoc": false,
+        "no-single-declare-module": false,
+        "no-trailing-whitespace": false,
+        "no-unnecessary-class": false,
+        "semicolon": false,
+        "strict-export-declare-modifiers": false
+    }
+}


### PR DESCRIPTION
Embarrassingly, my last PR (#216) introduced a syntax error in the type definition. This PR fixes that error and also adds `dtslint` as part of the Travis CI process, so that this won't happen again.

* Fixes the syntax error
* Modifies the `npm test` script to run `dtslint` on the type definition
* Adds tslint rules so that the existing index.d.ts passes linting
* Updates `.travis.yml` to use a newer version of Node, as required by dtslint

Here's an example build showing the original error:

https://travis-ci.org/MichaelMarner/react-native-google-analytics-bridge/builds/334576677

Sorry again for introducing the error in the first place.