### PR TITLE
Tell rn to set up on main queue to suppress warning

### DIFF
--- a/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
+++ b/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.m
@@ -36,6 +36,11 @@ NSString *staticTrackerId;
     return @{ @"nativeTrackerId": staticTrackerId != nil ? staticTrackerId : [NSNull null] };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(trackScreenView:(NSString *)trackerId screenName:(NSString *)screenName)


### PR DESCRIPTION
This would suppress the following warning.

> Module RCTGoogleAnalyticsBridge requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.

ref: https://github.com/wix/react-native-navigation/issues/1982