### PR TITLE
SupportRNv56

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,13 +2,20 @@ apply plugin: 'com.android.library'
 
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "+"
 
+def _ext = rootProject.ext
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 23
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '23.0.1'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 22
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -20,7 +27,7 @@ android {
 
 dependencies {
   def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
-    compile 'com.facebook.react:react-native:+'
+    compile "com.facebook.react:react-native:${_reactNativeVersion}"
     compile "com.google.android.gms:play-services-analytics:$googlePlayServicesVersion"
 
 }


### PR DESCRIPTION
PR to support React Native 56. The implemented fix was discussed in https://github.com/idehub/react-native-google-analytics-bridge/issues/259. I tested this on my app and everything was working as intended.