### PR TITLE
Fix 0 value

### DIFF
--- a/src/GoogleAnalyticsTracker.ts
+++ b/src/GoogleAnalyticsTracker.ts
@@ -165,7 +165,7 @@ class GoogleAnalyticsTracker {
       category,
       action,
       eventMetadata && eventMetadata.label,
-      eventMetadata && eventMetadata.value && eventMetadata.value.toString(),
+      eventMetadata && eventMetadata.value != null && eventMetadata.value.toString(),
       payload
     );
   }


### PR DESCRIPTION
If the metadata value is 0, it will be falsy and thus returned after evaluating the second expression, effectively skipping the `toString()` call, and causing `JSON value '0' of type NSNumber cannot be converted to NSString` error (similar to #102). This fix checks for true nullability.