### PR TITLE
Explicitly return null for eventMetadata label and value

### DIFF
--- a/src/GoogleAnalyticsTracker.ts
+++ b/src/GoogleAnalyticsTracker.ts
@@ -164,8 +164,8 @@ class GoogleAnalyticsTracker {
       this.id,
       category,
       action,
-      eventMetadata && eventMetadata.label,
-      eventMetadata && eventMetadata.value != null && eventMetadata.value.toString(),
+      (eventMetadata && eventMetadata.label ? eventMetadata.label : null),
+      (eventMetadata && eventMetadata.value != null ? eventMetadata.value.toString() : null),
       payload
     );
   }


### PR DESCRIPTION
Resolves #290 

The problem seems to be that if the eventMetadata value is omitted or set to `null`, `false` is passed to the native module. React-native converts this to a NSNumber with value 0 instead of null, and react-native complains that it can't convert a NSNumber into a string.

This fix explicitly passes null to the native module, which should cause react-native to correctly pass null to the native method.

At least for my use case, this seems to work correctly.