### PR TITLE
Fixed gradle warning of deprecated 'compile' configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    compile "com.google.android.gms:play-services-analytics:${safeExtGet('googlePlayServicesVersion', '+')}"
-    compile "com.google.android.gms:play-services-tagmanager-v4-impl:${safeExtGet('googlePlayServicesVersion', '+')}"
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    implementation "com.google.android.gms:play-services-analytics:${safeExtGet('googlePlayServicesVersion', '+')}"
+    implementation "com.google.android.gms:play-services-tagmanager-v4-impl:${safeExtGet('googlePlayServicesVersion', '+')}"
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
While trying to remove all deprecated warnings I stumbled upon this library not being updated yet. A quick and simple fix for this is to use `implementation` instead of `compile`.

The original Gradle warning shown;
```
> Configure project :react-native-google-analytics-bridge
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```